### PR TITLE
desktop (arm64, x64, and x86) binaries need to be packed in a fat framworks before building XCFramworks

### DIFF
--- a/api/multiplatform-swiftpackage.api
+++ b/api/multiplatform-swiftpackage.api
@@ -1,5 +1,4 @@
 public final class com/chromaticnoise/multiplatformswiftpackage/MultiplatformSwiftPackagePlugin : org/gradle/api/Plugin {
-	public static final field Companion Lcom/chromaticnoise/multiplatformswiftpackage/MultiplatformSwiftPackagePlugin$Companion;
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V
 	public fun apply (Lorg/gradle/api/Project;)V

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,11 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+project.tasks.named("processResources", Copy::class.java) {
+    // https://github.com/gradle/gradle/issues/17236
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
 extensions.findByName("buildScan")?.withGroovyBuilder {
     setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
     setProperty("termsOfServiceAgree", "yes")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,9 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
     }
     dependencies {
-        classpath("org.jetbrains.kotlinx:binary-compatibility-validator:0.2.4")
+        classpath("org.jetbrains.kotlinx:binary-compatibility-validator:0.9.0")
     }
 }
 
@@ -20,16 +19,16 @@ plugins {
 version = "2.0.3"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    compileOnly(kotlin("gradle-plugin", "1.5.30"))
-    testImplementation("io.kotest:kotest-runner-junit5:4.3.0")
-    testImplementation("io.kotest:kotest-assertions-core:4.3.0")
-    testImplementation("io.kotest:kotest-property:4.3.0")
-    testImplementation("io.mockk:mockk:1.10.0")
-    testImplementation(kotlin("gradle-plugin", "1.5.30"))
+    compileOnly(kotlin("gradle-plugin", "1.6.21"))
+    testImplementation("io.kotest:kotest-runner-junit5:5.2.3")
+    testImplementation("io.kotest:kotest-assertions-core:5.2.3")
+    testImplementation("io.kotest:kotest-property:5.2.3")
+    testImplementation("io.mockk:mockk:1.12.3")
+    testImplementation(kotlin("gradle-plugin", "1.6.21"))
 }
 
 java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/MultiplatformSwiftPackagePlugin.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/MultiplatformSwiftPackagePlugin.kt
@@ -2,7 +2,9 @@ package com.chromaticnoise.multiplatformswiftpackage
 
 import com.chromaticnoise.multiplatformswiftpackage.domain.AppleTarget
 import com.chromaticnoise.multiplatformswiftpackage.domain.platforms
+import com.chromaticnoise.multiplatformswiftpackage.task.*
 import com.chromaticnoise.multiplatformswiftpackage.task.registerCreateSwiftPackageTask
+import com.chromaticnoise.multiplatformswiftpackage.task.registerCreateUniversalIosSimulatorFrameworkTask
 import com.chromaticnoise.multiplatformswiftpackage.task.registerCreateXCFrameworkTask
 import com.chromaticnoise.multiplatformswiftpackage.task.registerCreateZipFileTask
 import org.gradle.api.Plugin
@@ -25,6 +27,10 @@ public class MultiplatformSwiftPackagePlugin : Plugin<Project> {
                     nativeTargets = kmpExtension.targets.toList(),
                     platforms = extension.targetPlatforms.platforms
                 )
+                project.registerCreateUniversalMacosFrameworkTask()
+                project.registerCreateUniversalIosSimulatorFrameworkTask()
+                project.registerCreateUniversalWatchosSimulatorFrameworkTask()
+                project.registerCreateUniversalTvosSimulatorFrameworkTask()
                 project.registerCreateXCFrameworkTask()
                 project.registerCreateZipFileTask()
                 project.registerCreateSwiftPackageTask()

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/AppleFramework.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/AppleFramework.kt
@@ -1,12 +1,14 @@
 package com.chromaticnoise.multiplatformswiftpackage.domain
 
+import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBinary
 import java.io.File
 
 internal class AppleFramework(
     val outputFile: AppleFrameworkOutputFile,
     val name: AppleFrameworkName,
-    val linkTask: AppleFrameworkLinkTask
+    val linkTask: AppleFrameworkLinkTask,
+    val framework: Framework? = null
 ) {
 
     val dsymFile: File get() = File(outputFile.parent, "${name.value}.framework.dSYM")
@@ -18,7 +20,8 @@ internal fun AppleFramework.Companion.of(binary: NativeBinary?): AppleFramework?
     AppleFramework(
         AppleFrameworkOutputFile(it.outputFile),
         AppleFrameworkName(it.baseName),
-        AppleFrameworkLinkTask(it.linkTaskName)
+        AppleFrameworkLinkTask(it.linkTaskName),
+        binary as Framework
     )
 }
 

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
@@ -111,7 +111,7 @@ internal fun Project.registerCreateUniversalIosSimulatorFrameworkTask() =
         if (targets.isNotEmpty()) {
             val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
             destinationDir = buildDir.resolve("bin/iosSimulatorUniversal/${buildType}Framework")
-            from(targets.map { it.framework!! } )
+            from(targets.mapNotNull { it.framework } )
         }
     }
 
@@ -126,7 +126,7 @@ internal fun Project.registerCreateUniversalWatchosSimulatorFrameworkTask() =
         if (targets.isNotEmpty()) {
             val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
             destinationDir = buildDir.resolve("bin/watchosSimulatorUniversal/$buildType")
-            from(targets.map { it.framework!! })
+            from(targets.mapNotNull { it.framework })
         }
     }
 
@@ -141,7 +141,7 @@ internal fun Project.registerCreateUniversalTvosSimulatorFrameworkTask() =
         if (targets.isNotEmpty()) {
             val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
             destinationDir = buildDir.resolve("bin/tvosSimulatorUniversal/$buildType")
-            from(targets.map { it.framework!! })
+            from(targets.mapNotNull { it.framework })
         }
     }
 

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
@@ -49,7 +49,7 @@ internal fun Project.registerCreateUniversalMacosFrameworkTask() =
         group = "multiplatform-swift-package"
         description = "Creates a universal (fat) macos framework"
         val configuration = getConfigurationOrThrow()
-        onlyIf{ getMacosFrameworks(configuration).size > 1 }
+        onlyIf { getMacosFrameworks(configuration).size > 1 }
         val targets = getMacosFrameworks(configuration)
         dependsOn(targets.map { it.linkTask.name })
         doLast {
@@ -105,13 +105,13 @@ internal fun Project.registerCreateUniversalIosSimulatorFrameworkTask() =
         group = "multiplatform-swift-package"
         description = "Creates a universal (fat) ios simulator framework"
         val configuration = getConfigurationOrThrow()
-        onlyIf{ getIosSimulatorFrameworks(configuration).size > 1 }
+        onlyIf { getIosSimulatorFrameworks(configuration).size > 1 }
         val targets = getIosSimulatorFrameworks(configuration)
         dependsOn(targets.map { it.linkTask.name })
         if (targets.isNotEmpty()) {
             val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
             destinationDir = buildDir.resolve("bin/iosSimulatorUniversal/${buildType}Framework")
-            from(targets.mapNotNull { it.framework } )
+            from(targets.mapNotNull { it.framework })
         }
     }
 
@@ -120,7 +120,7 @@ internal fun Project.registerCreateUniversalWatchosSimulatorFrameworkTask() =
         group = "multiplatform-swift-package"
         description = "Creates a universal (fat) watchos simulator framework"
         val configuration = getConfigurationOrThrow()
-        onlyIf{ getWatchosSimulatorFrameworks(configuration).size > 1 }
+        onlyIf { getWatchosSimulatorFrameworks(configuration).size > 1 }
         val targets = getWatchosSimulatorFrameworks(configuration)
         dependsOn(targets.map { it.linkTask.name })
         if (targets.isNotEmpty()) {
@@ -135,7 +135,7 @@ internal fun Project.registerCreateUniversalTvosSimulatorFrameworkTask() =
         group = "multiplatform-swift-package"
         description = "Creates a universal (fat) tvos simulator framework"
         val configuration = getConfigurationOrThrow()
-        onlyIf{ getTvosSimulatorFrameworks(configuration).size > 1 }
+        onlyIf { getTvosSimulatorFrameworks(configuration).size > 1 }
         val targets = getTvosSimulatorFrameworks(configuration)
         dependsOn(targets.map { it.linkTask.name })
         if (targets.isNotEmpty()) {
@@ -150,16 +150,16 @@ internal fun removeMonoFrameworksAndAddUniversalFrameworkIfNeeded(
     binFolderPrefix: String,
     buildDir: File,
     monoFrameworks: List<AppleFramework>,
-    outputFrameworks: MutableList<AppleFramework>)
-{
-    if (monoFrameworks.size > 1){
+    outputFrameworks: MutableList<AppleFramework>
+) {
+    if (monoFrameworks.size > 1) {
         monoFrameworks.forEach { mono ->
-            outputFrameworks.removeIf{ mono.outputFile == it.outputFile}
+            outputFrameworks.removeIf { mono.outputFile == it.outputFile }
         }
         val frameworkName = monoFrameworks[0].name
         val buildType = if (monoFrameworks[0].linkTask.name.contains("Release")) "release" else "debug"
         val destinationDir = buildDir.resolve("bin/${binFolderPrefix}Universal/${buildType}Framework")
-        val outputFile = AppleFrameworkOutputFile(File(destinationDir ,"${frameworkName.value}.framework"))
+        val outputFile = AppleFrameworkOutputFile(File(destinationDir, "${frameworkName.value}.framework"))
         outputFrameworks.add(
             AppleFramework(
                 outputFile,
@@ -171,14 +171,15 @@ internal fun removeMonoFrameworksAndAddUniversalFrameworkIfNeeded(
 }
 
 
-
 internal fun Project.registerCreateXCFrameworkTask() = tasks.register("createXCFramework", Exec::class.java) {
     group = "multiplatform-swift-package"
     description = "Creates an XCFramework for all declared Apple targets"
 
     val configuration = getConfigurationOrThrow()
-    val xcFrameworkDestination = File(configuration.outputDirectory.value, "${configuration.packageName.value}.xcframework")
-    val outputFrameworks = configuration.appleTargets.mapNotNull { it.getFramework(configuration.buildConfiguration) }.toMutableList()
+    val xcFrameworkDestination =
+        File(configuration.outputDirectory.value, "${configuration.packageName.value}.xcframework")
+    val outputFrameworks =
+        configuration.appleTargets.mapNotNull { it.getFramework(configuration.buildConfiguration) }.toMutableList()
 
     dependsOn(outputFrameworks.map { it.linkTask.name })
     dependsOn("createUniversalMacosFramework")

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
@@ -110,6 +110,7 @@ internal fun Project.registerCreateUniversalIosSimulatorFrameworkTask() =
         dependsOn(targets.map { it.linkTask.name })
         if (targets.isNotEmpty()) {
             val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
+            baseName = configuration.packageName.value
             destinationDir = buildDir.resolve("bin/iosSimulatorUniversal/${buildType}Framework")
             from(targets.mapNotNull { it.framework })
         }
@@ -125,6 +126,7 @@ internal fun Project.registerCreateUniversalWatchosSimulatorFrameworkTask() =
         dependsOn(targets.map { it.linkTask.name })
         if (targets.isNotEmpty()) {
             val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
+            baseName = configuration.packageName.value
             destinationDir = buildDir.resolve("bin/watchosSimulatorUniversal/$buildType")
             from(targets.mapNotNull { it.framework })
         }
@@ -140,6 +142,7 @@ internal fun Project.registerCreateUniversalTvosSimulatorFrameworkTask() =
         dependsOn(targets.map { it.linkTask.name })
         if (targets.isNotEmpty()) {
             val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
+            baseName = configuration.packageName.value
             destinationDir = buildDir.resolve("bin/tvosSimulatorUniversal/$buildType")
             from(targets.mapNotNull { it.framework })
         }

--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
@@ -1,9 +1,176 @@
 package com.chromaticnoise.multiplatformswiftpackage.task
 
+import com.chromaticnoise.multiplatformswiftpackage.domain.*
+import com.chromaticnoise.multiplatformswiftpackage.domain.PluginConfiguration
 import com.chromaticnoise.multiplatformswiftpackage.domain.getConfigurationOrThrow
 import org.gradle.api.Project
 import org.gradle.api.tasks.Exec
+import org.gradle.kotlin.dsl.task
+import org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask
 import java.io.File
+
+
+internal fun getMacosFrameworks(configuration: PluginConfiguration): List<AppleFramework> {
+    return configuration.appleTargets.mapNotNull { it.getFramework(configuration.buildConfiguration) }
+        .filter {
+            it.linkTask.name.contains("MacosX64") || it.linkTask.name.contains("MacosArm64")
+        }
+}
+
+internal fun getIosSimulatorFrameworks(configuration: PluginConfiguration): List<AppleFramework> {
+    return configuration.appleTargets.mapNotNull { it.getFramework(configuration.buildConfiguration) }
+        .filter {
+            it.linkTask.name.contains("IosX64") || it.linkTask.name.contains("IosSimulatorArm64")
+        }
+}
+
+internal fun getWatchosSimulatorFrameworks(configuration: PluginConfiguration): List<AppleFramework> {
+    return configuration.appleTargets.mapNotNull { it.getFramework(configuration.buildConfiguration) }
+        .filter {
+            it.linkTask.name.contains("watchosX86")
+                    || it.linkTask.name.contains("watchosX64")
+                    || it.linkTask.name.contains("watchosSimulatorArm64")
+        }
+}
+
+internal fun getTvosSimulatorFrameworks(configuration: PluginConfiguration): List<AppleFramework> {
+    return configuration.appleTargets.mapNotNull { it.getFramework(configuration.buildConfiguration) }
+        .filter {
+            it.linkTask.name.contains("tvosX64") || it.linkTask.name.contains("tvosSimulatorArm64")
+        }
+}
+
+internal fun Project.registerCreateUniversalMacosFrameworkTask() =
+    task("createUniversalMacosFramework") {
+        // Can't use FatFrameworkTask 🙃
+        // https://youtrack.jetbrains.com/issue/KT-47355/Support-macos-target-for-FatFramework-task
+        // workaround:
+        // https://gist.github.com/JUSTINMKAUFMAN/6627c3c8571563b36efc9c832f6fa2b1
+        group = "multiplatform-swift-package"
+        description = "Creates a universal (fat) macos framework"
+        val configuration = getConfigurationOrThrow()
+        onlyIf{ getMacosFrameworks(configuration).size > 1 }
+        val targets = getMacosFrameworks(configuration)
+        dependsOn(targets.map { it.linkTask.name })
+        doLast {
+            if (targets.isNotEmpty()) {
+                delete(buildDir.resolve("bin/macosUniversal"))
+                val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
+                val frameworkName = targets[0].name.value
+                val destinationDir = buildDir.resolve("bin/macosUniversal/${buildType}Framework")
+                mkdir(destinationDir.parent)
+                mkdir(destinationDir)
+                val tempUniversalBinaryLocation = File(destinationDir, frameworkName)
+                exec {
+                    commandLine(
+                        "lipo",
+                        "-create",
+                        "${targets[0].outputFile.path}/Versions/A/${frameworkName}",
+                        "${targets[1].outputFile.path}/Versions/A/${frameworkName}",
+                        "-output",
+                        tempUniversalBinaryLocation.path
+                    )
+                }
+                val aFramework = targets[0].outputFile.path
+                copy {
+                    from(aFramework)
+                    into(File(destinationDir, "$frameworkName.framework"))
+                }
+                // delete the old mono framework binary we copied here
+                val binaryFinalLocation = File(destinationDir, "${frameworkName}.framework/Versions/A/$frameworkName")
+                val binaryFinalSymlinkLocation = File(destinationDir, "${frameworkName}.framework/$frameworkName")
+                delete(binaryFinalLocation)
+                delete(binaryFinalSymlinkLocation)
+                // copy new universal binary to binaryFinalSymlinkLocation
+                copy {
+                    from(tempUniversalBinaryLocation)
+                    into(File(destinationDir, "$frameworkName.framework/Versions/A"))
+                }
+                delete(tempUniversalBinaryLocation)
+                exec {
+                    //recreate the symlink normally to the binary normally in framework folder
+                    commandLine(
+                        "ln",
+                        "-s",
+                        binaryFinalLocation.toPath(),
+                        binaryFinalSymlinkLocation.toPath()
+                    )
+                }
+            }
+        }
+    }
+
+internal fun Project.registerCreateUniversalIosSimulatorFrameworkTask() =
+    task<FatFrameworkTask>("createUniversalIosSimulatorFramework") {
+        group = "multiplatform-swift-package"
+        description = "Creates a universal (fat) ios simulator framework"
+        val configuration = getConfigurationOrThrow()
+        onlyIf{ getIosSimulatorFrameworks(configuration).size > 1 }
+        val targets = getIosSimulatorFrameworks(configuration)
+        dependsOn(targets.map { it.linkTask.name })
+        if (targets.isNotEmpty()) {
+            val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
+            destinationDir = buildDir.resolve("bin/iosSimulatorUniversal/${buildType}Framework")
+            from(targets.map { it.framework!! } )
+        }
+    }
+
+internal fun Project.registerCreateUniversalWatchosSimulatorFrameworkTask() =
+    tasks.register("createUniversalWatchosSimulatorFramework", FatFrameworkTask::class.java) {
+        group = "multiplatform-swift-package"
+        description = "Creates a universal (fat) watchos simulator framework"
+        val configuration = getConfigurationOrThrow()
+        onlyIf{ getWatchosSimulatorFrameworks(configuration).size > 1 }
+        val targets = getWatchosSimulatorFrameworks(configuration)
+        dependsOn(targets.map { it.linkTask.name })
+        if (targets.isNotEmpty()) {
+            val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
+            destinationDir = buildDir.resolve("bin/watchosSimulatorUniversal/$buildType")
+            from(targets.map { it.framework!! })
+        }
+    }
+
+internal fun Project.registerCreateUniversalTvosSimulatorFrameworkTask() =
+    tasks.register("createUniversalTvosSimulatorFramework", FatFrameworkTask::class.java) {
+        group = "multiplatform-swift-package"
+        description = "Creates a universal (fat) tvos simulator framework"
+        val configuration = getConfigurationOrThrow()
+        onlyIf{ getTvosSimulatorFrameworks(configuration).size > 1 }
+        val targets = getTvosSimulatorFrameworks(configuration)
+        dependsOn(targets.map { it.linkTask.name })
+        if (targets.isNotEmpty()) {
+            val buildType = if (targets[0].linkTask.name.contains("Release")) "release" else "debug"
+            destinationDir = buildDir.resolve("bin/tvosSimulatorUniversal/$buildType")
+            from(targets.map { it.framework!! })
+        }
+    }
+
+
+internal fun removeMonoFrameworksAndAddUniversalFrameworkIfNeeded(
+    binFolderPrefix: String,
+    buildDir: File,
+    monoFrameworks: List<AppleFramework>,
+    outputFrameworks: MutableList<AppleFramework>)
+{
+    if (monoFrameworks.size > 1){
+        monoFrameworks.forEach { mono ->
+            outputFrameworks.removeIf{ mono.outputFile == it.outputFile}
+        }
+        val frameworkName = monoFrameworks[0].name
+        val buildType = if (monoFrameworks[0].linkTask.name.contains("Release")) "release" else "debug"
+        val destinationDir = buildDir.resolve("bin/${binFolderPrefix}Universal/${buildType}Framework")
+        val outputFile = AppleFrameworkOutputFile(File(destinationDir ,"${frameworkName.value}.framework"))
+        outputFrameworks.add(
+            AppleFramework(
+                outputFile,
+                frameworkName,
+                AppleFrameworkLinkTask("")
+            )
+        )
+    }
+}
+
+
 
 internal fun Project.registerCreateXCFrameworkTask() = tasks.register("createXCFramework", Exec::class.java) {
     group = "multiplatform-swift-package"
@@ -11,22 +178,56 @@ internal fun Project.registerCreateXCFrameworkTask() = tasks.register("createXCF
 
     val configuration = getConfigurationOrThrow()
     val xcFrameworkDestination = File(configuration.outputDirectory.value, "${configuration.packageName.value}.xcframework")
-    val frameworks = configuration.appleTargets.mapNotNull { it.getFramework(configuration.buildConfiguration) }
+    val outputFrameworks = configuration.appleTargets.mapNotNull { it.getFramework(configuration.buildConfiguration) }.toMutableList()
 
-    dependsOn(frameworks.map { it.linkTask.name })
+    dependsOn(outputFrameworks.map { it.linkTask.name })
+    dependsOn("createUniversalMacosFramework")
+    dependsOn("createUniversalIosSimulatorFramework")
+    dependsOn("createUniversalWatchosSimulatorFramework")
+    dependsOn("createUniversalTvosSimulatorFramework")
+
+    val macosFrameworks = getMacosFrameworks(configuration)
+    removeMonoFrameworksAndAddUniversalFrameworkIfNeeded(
+        "macos",
+        buildDir,
+        macosFrameworks,
+        outputFrameworks
+    )
+    val iosSimulatorFrameworks = getIosSimulatorFrameworks(configuration)
+    removeMonoFrameworksAndAddUniversalFrameworkIfNeeded(
+        "iosSimulator",
+        buildDir,
+        iosSimulatorFrameworks,
+        outputFrameworks
+    )
+    val watchosSimulatorFrameworks = getWatchosSimulatorFrameworks(configuration)
+    removeMonoFrameworksAndAddUniversalFrameworkIfNeeded(
+        "watchosSimulator",
+        buildDir,
+        watchosSimulatorFrameworks,
+        outputFrameworks
+    )
+    val tvosSimulatorFrameworks = getTvosSimulatorFrameworks(configuration)
+    removeMonoFrameworksAndAddUniversalFrameworkIfNeeded(
+        "tvosSimulator",
+        buildDir,
+        tvosSimulatorFrameworks,
+        outputFrameworks
+    )
+
 
     executable = "xcodebuild"
     args(mutableListOf<String>().apply {
         add("-create-xcframework")
         add("-output")
         add(xcFrameworkDestination.path)
-        frameworks.forEach { framework ->
+        outputFrameworks.forEach { framework ->
             add("-framework")
             add(framework.outputFile.path)
 
             framework.dsymFile.takeIf { it.exists() }?.let { dsymFile ->
                 add("-debug-symbols")
-                add(dsymFile.path)
+                add(dsymFile.absolutePath)
             }
         }
     })

--- a/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PluginConfigurationTest.kt
+++ b/src/test/kotlin/com/chromaticnoise/multiplatformswiftpackage/domain/PluginConfigurationTest.kt
@@ -95,7 +95,7 @@ class PluginConfigurationTest : BehaviorSpec() {
 
     private lateinit var project: Project
 
-    override fun beforeTest(testCase: TestCase) {
+    override suspend fun beforeTest(testCase: TestCase)  {
         project = mockk(relaxed = true) {
             every { projectDir } returns File("")
         }


### PR DESCRIPTION
With your pr, I'm running into this issue: https://developer.apple.com/forums/thread/666335

Before making an XCFramwork: macos desktop (including simulators) arm64, x64, and x86 binaries need to be packed in a fat frameworks before building the XCFramworks

I also updated kotlin and dependencies